### PR TITLE
Dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 POSTGRES_PORT=5432
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=hydra
-POSTGRES_DB_NAME=mydb
+POSTGRES_DB_NAME=postgres
 POSTGRES_BASE_VERSION=16.1
 DATABASE_URL=postgres://{user}:{password}@{hostname}:{port}/{database-name}
 CDK_DEPLOY_REGIONS=us-east-1,us-east-2,us-west-1,us-west-2

--- a/bin/hydra-docker-image-ecr-deployment-cdk.ts
+++ b/bin/hydra-docker-image-ecr-deployment-cdk.ts
@@ -15,6 +15,14 @@ const environments = process.env.ENVIRONMENTS?.split(',') ?? ['dev']; // Parsing
 
 const DEFAULT_IMAGE_VERSION = 'latest';
 
+const envTyped = {
+  POSTGRES_PORT:process.env.POSTGRES_PORT ?? '5432',
+  POSTGRES_USER:process.env.POSTGRES_USER ?? 'postgres',
+  POSTGRES_PASSWORD:process.env.POSTGRES_PASSWORD ?? 'postgres',
+  POSTGRES_BASE_VERSION:process.env.POSTGRES_BASE_VERSION ?? '16.1',
+  POSTGRES_DB_NAME:process.env.POSTGRES_DB_NAME ?? 'hydra',
+}
+
 for (const cdkRegion of cdkRegions) {
   for (const environment of environments) {
     new HydraDockerImageEcrDeploymentCdkStack(app, `HydraDockerImageEcrDeploymentCdkStack-${cdkRegion}-${environment}`, {
@@ -28,7 +36,8 @@ for (const cdkRegion of cdkRegions) {
       repositoryName: `${process.env.ECR_REPOSITORY_NAME}-${environment}` ?? 'hydradatabase-docker-image-ecr-deployment-cdk',
       appName: process.env.APP_NAME ?? 'hydradatabase',
       imageVersion: process.env.IMAGE_VERSION ?? DEFAULT_IMAGE_VERSION,
-      environment: environment
+      environment: environment,
+      envTyped: envTyped,
     });
   }
 }

--- a/bin/hydra-docker-image-ecr-deployment-cdk.ts
+++ b/bin/hydra-docker-image-ecr-deployment-cdk.ts
@@ -16,11 +16,11 @@ const environments = process.env.ENVIRONMENTS?.split(',') ?? ['dev']; // Parsing
 const DEFAULT_IMAGE_VERSION = 'latest';
 
 const envTyped = {
-  POSTGRES_PORT:process.env.POSTGRES_PORT ?? '5432',
-  POSTGRES_USER:process.env.POSTGRES_USER ?? 'postgres',
-  POSTGRES_PASSWORD:process.env.POSTGRES_PASSWORD ?? 'postgres',
-  POSTGRES_BASE_VERSION:process.env.POSTGRES_BASE_VERSION ?? '16.1',
-  POSTGRES_DB_NAME:process.env.POSTGRES_DB_NAME ?? 'hydra',
+  POSTGRES_PORT: process.env.POSTGRES_PORT ?? '5432',
+  POSTGRES_USER: process.env.POSTGRES_USER ?? 'postgres',
+  POSTGRES_PASSWORD: process.env.POSTGRES_PASSWORD ?? 'postgres',
+  POSTGRES_BASE_VERSION: process.env.POSTGRES_BASE_VERSION ?? '16.1',
+  POSTGRES_DB_NAME: process.env.POSTGRES_DB_NAME ?? 'hydra',
 }
 
 for (const cdkRegion of cdkRegions) {

--- a/lib/HydraDockerImageEcrDeploymentCdkStackProps.ts
+++ b/lib/HydraDockerImageEcrDeploymentCdkStackProps.ts
@@ -1,8 +1,10 @@
 import * as cdk from 'aws-cdk-lib';
+import { IEnvTyped } from '../process-env-typed';
 
 export interface HydraDockerImageEcrDeploymentCdkStackProps extends cdk.StackProps {
     readonly repositoryName: string;
     readonly appName: string;
     imageVersion?: string;
     environment?: string;
+    envTyped: IEnvTyped;
 }

--- a/lib/hydra-docker-image-ecr-deployment-cdk-stack.ts
+++ b/lib/hydra-docker-image-ecr-deployment-cdk-stack.ts
@@ -5,7 +5,6 @@ import * as ecrDeploy from 'cdk-ecr-deployment';
 import * as ecr from 'aws-cdk-lib/aws-ecr';
 import { DockerImageAsset, Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { HydraDockerImageEcrDeploymentCdkStackProps } from './HydraDockerImageEcrDeploymentCdkStackProps';
-import { EnvTyped } from '../process-env-typed';
 
 export class HydraDockerImageEcrDeploymentCdkStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: HydraDockerImageEcrDeploymentCdkStackProps) {
@@ -24,11 +23,11 @@ export class HydraDockerImageEcrDeploymentCdkStack extends cdk.Stack {
     const dockerImageAsset = new DockerImageAsset(this, `${props.appName}-${props.environment}-DockerImageAsset`, {
       directory: path.join(__dirname, '../coreservices'),
       buildArgs: {
-        POSTGRES_PORT: EnvTyped.POSTGRES_PORT,
-        POSTGRES_USER: EnvTyped.POSTGRES_USER,
-        POSTGRES_PASSWORD: EnvTyped.POSTGRES_PASSWORD,
-        POSTGRES_BASE_VERSION: EnvTyped.POSTGRES_BASE_VERSION,
-        POSTGRES_DB_NAME: EnvTyped.POSTGRES_DB_NAME,
+        POSTGRES_PORT: props.envTyped.POSTGRES_PORT,
+        POSTGRES_USER: props.envTyped.POSTGRES_USER,
+        POSTGRES_PASSWORD: props.envTyped.POSTGRES_PASSWORD,
+        POSTGRES_BASE_VERSION: props.envTyped.POSTGRES_BASE_VERSION,
+        POSTGRES_DB_NAME: props.envTyped.POSTGRES_DB_NAME,
       },
       platform: Platform.LINUX_ARM64
     });

--- a/lib/hydra-docker-image-ecr-kms-deployment-cdk-stack.ts
+++ b/lib/hydra-docker-image-ecr-kms-deployment-cdk-stack.ts
@@ -6,7 +6,6 @@ import * as ecr from 'aws-cdk-lib/aws-ecr';
 import * as kms from 'aws-cdk-lib/aws-kms';
 import { DockerImageAsset, Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { HydraDockerImageEcrDeploymentCdkStackProps } from './HydraDockerImageEcrDeploymentCdkStackProps';
-import { EnvTyped } from '../process-env-typed';
 
 export class HydraDockerImageEcrDeploymentCdkStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: HydraDockerImageEcrDeploymentCdkStackProps) {
@@ -32,11 +31,11 @@ export class HydraDockerImageEcrDeploymentCdkStack extends cdk.Stack {
     const dockerImageAsset = new DockerImageAsset(this, `${props.appName}-${props.environment}-DockerImageAsset`, {
       directory: path.join(__dirname, '../coreservices'),
       buildArgs: {
-        POSTGRES_PORT: EnvTyped.POSTGRES_PORT,
-        POSTGRES_USER: EnvTyped.POSTGRES_USER,
-        POSTGRES_PASSWORD: EnvTyped.POSTGRES_PASSWORD,
-        POSTGRES_BASE_VERSION: EnvTyped.POSTGRES_BASE_VERSION,
-        POSTGRES_DB_NAME: EnvTyped.POSTGRES_DB_NAME,
+        POSTGRES_PORT: props.envTyped.POSTGRES_PORT,
+        POSTGRES_USER: props.envTyped.POSTGRES_USER,
+        POSTGRES_PASSWORD: props.envTyped.POSTGRES_PASSWORD,
+        POSTGRES_BASE_VERSION: props.envTyped.POSTGRES_BASE_VERSION,
+        POSTGRES_DB_NAME: props.envTyped.POSTGRES_DB_NAME,
       },
       platform: Platform.LINUX_ARM64
     });

--- a/process-env-typed.ts
+++ b/process-env-typed.ts
@@ -1,7 +1,7 @@
-export const EnvTyped = {
-    POSTGRES_PORT:process.env.POSTGRES_PORT ?? '5432',
-    POSTGRES_USER:process.env.POSTGRES_USER ?? 'postgres',
-    POSTGRES_PASSWORD:process.env.POSTGRES_PASSWORD ?? 'postgres',
-    POSTGRES_BASE_VERSION:process.env.POSTGRES_BASE_VERSION ?? '16',
-    POSTGRES_DB_NAME:process.env.POSTGRES_DB_NAME ?? 'hydra',
+export interface IEnvTyped {
+    POSTGRES_PORT: string;
+    POSTGRES_USER: string;
+    POSTGRES_PASSWORD: string;
+    POSTGRES_BASE_VERSION: string;
+    POSTGRES_DB_NAME: string;
 }


### PR DESCRIPTION
## type:
Refactoring

___
## description:
This PR includes several changes related to environment variables and Docker image deployment:
- Refactored the way environment variables are handled by introducing a new `envTyped` object, which includes `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_BASE_VERSION`, and `POSTGRES_DB_NAME`. These variables are now passed as properties to the `HydraDockerImageEcrDeploymentCdkStackProps` interface.
- Updated the Docker image deployment in `hydra-docker-image-ecr-deployment-cdk-stack.ts` and `hydra-docker-image-ecr-kms-deployment-cdk-stack.ts` to use the new `envTyped` object.
- Removed the `EnvTyped` constant from `process-env-typed.ts` and replaced it with an `IEnvTyped` interface.
- Updated the `.env.example` file to reflect the changes in environment variables.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `bin/hydra-docker-image-ecr-deployment-cdk.ts`: Introduced a new `envTyped` object to handle environment variables and passed it as a property to the `HydraDockerImageEcrDeploymentCdkStack` constructor.
- `lib/HydraDockerImageEcrDeploymentCdkStackProps.ts`: Added `envTyped` as a new property to the `HydraDockerImageEcrDeploymentCdkStackProps` interface.
- `lib/hydra-docker-image-ecr-deployment-cdk-stack.ts`: Updated the Docker image deployment to use the new `envTyped` object for build arguments.
- `lib/hydra-docker-image-ecr-kms-deployment-cdk-stack.ts`: Similar to `hydra-docker-image-ecr-deployment-cdk-stack.ts`, updated the Docker image deployment to use the new `envTyped` object for build arguments.
- `process-env-typed.ts`: Removed the `EnvTyped` constant and replaced it with an `IEnvTyped` interface.
- `.env.example`: Updated the `POSTGRES_DB_NAME` value to 'postgres'.
</details>
